### PR TITLE
Fix recording rule errors the label values change

### DIFF
--- a/examples/_gen/getting-started.yml
+++ b/examples/_gen/getting-started.yml
@@ -105,10 +105,9 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+      sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+      sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/getting-started.yml
+++ b/examples/_gen/getting-started.yml
@@ -105,10 +105,10 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/getting-started.yml
+++ b/examples/_gen/getting-started.yml
@@ -105,9 +105,10 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-      sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-      sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/getting-started.yml
+++ b/examples/_gen/getting-started.yml
@@ -105,7 +105,7 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])

--- a/examples/_gen/home-wifi.yml
+++ b/examples/_gen/home-wifi.yml
@@ -105,10 +105,10 @@ groups:
       sloth_slo: good-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh
@@ -346,10 +346,10 @@ groups:
       sloth_slo: risk-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh

--- a/examples/_gen/home-wifi.yml
+++ b/examples/_gen/home-wifi.yml
@@ -105,7 +105,7 @@ groups:
       sloth_slo: good-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
@@ -346,7 +346,7 @@ groups:
       sloth_slo: risk-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])

--- a/examples/_gen/home-wifi.yml
+++ b/examples/_gen/home-wifi.yml
@@ -105,10 +105,10 @@ groups:
       sloth_slo: good-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
+      sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
+      sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh
@@ -346,10 +346,10 @@ groups:
       sloth_slo: risk-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
+      sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
+      sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh

--- a/examples/_gen/home-wifi.yml
+++ b/examples/_gen/home-wifi.yml
@@ -105,10 +105,10 @@ groups:
       sloth_slo: good-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
-      sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
-      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
-      sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh
@@ -346,10 +346,10 @@ groups:
       sloth_slo: risk-wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
-      sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
-      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
-      sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh

--- a/examples/_gen/k8s-getting-started.yml
+++ b/examples/_gen/k8s-getting-started.yml
@@ -114,10 +114,10 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+    - expr: |-
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam

--- a/examples/_gen/k8s-getting-started.yml
+++ b/examples/_gen/k8s-getting-started.yml
@@ -114,7 +114,7 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |-
+    - expr: |
         sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
         /
         count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])

--- a/examples/_gen/k8s-getting-started.yml
+++ b/examples/_gen/k8s-getting-started.yml
@@ -114,9 +114,10 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-        sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-        sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    - expr: |
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam

--- a/examples/_gen/k8s-getting-started.yml
+++ b/examples/_gen/k8s-getting-started.yml
@@ -114,10 +114,9 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
-        /
-        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+        sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+        sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam

--- a/examples/_gen/k8s-home-wifi.yml
+++ b/examples/_gen/k8s-home-wifi.yml
@@ -117,10 +117,10 @@ spec:
         sloth_slo: good-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"}[30d])
+    - expr: |-
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
       labels:
         cluster: valhalla
         cmd: examplesgen.sh
@@ -358,10 +358,10 @@ spec:
         sloth_slo: risk-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"}[30d])
+    - expr: |-
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
       labels:
         cluster: valhalla
         cmd: examplesgen.sh

--- a/examples/_gen/k8s-home-wifi.yml
+++ b/examples/_gen/k8s-home-wifi.yml
@@ -117,7 +117,7 @@ spec:
         sloth_slo: good-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: |-
+    - expr: |
         sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
         /
         count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
@@ -358,7 +358,7 @@ spec:
         sloth_slo: risk-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: |-
+    - expr: |
         sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
         /
         count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])

--- a/examples/_gen/k8s-home-wifi.yml
+++ b/examples/_gen/k8s-home-wifi.yml
@@ -117,10 +117,10 @@ spec:
         sloth_slo: good-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
-        /
-        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
+        sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+        / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
+        sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
       labels:
         cluster: valhalla
         cmd: examplesgen.sh
@@ -358,10 +358,10 @@ spec:
         sloth_slo: risk-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
-        /
-        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
+        sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+        / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
+        sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
       labels:
         cluster: valhalla
         cmd: examplesgen.sh

--- a/examples/_gen/k8s-home-wifi.yml
+++ b/examples/_gen/k8s-home-wifi.yml
@@ -117,10 +117,10 @@ spec:
         sloth_slo: good-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
-        sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
-        / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction",
-        sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+    - expr: |
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-good-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="good-wifi-client-satisfaction"})[30d:])
       labels:
         cluster: valhalla
         cmd: examplesgen.sh
@@ -358,10 +358,10 @@ spec:
         sloth_slo: risk-wifi-client-satisfaction
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
-    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
-        sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
-        / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction",
-        sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+    - expr: |
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-risk-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="risk-wifi-client-satisfaction"})[30d:])
       labels:
         cluster: valhalla
         cmd: examplesgen.sh

--- a/examples/_gen/k8s-multifile.yml
+++ b/examples/_gen/k8s-multifile.yml
@@ -114,10 +114,9 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
-        /
-        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+        sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+        sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam
@@ -373,10 +372,9 @@ spec:
         sloth_window: 3d
         tier: "1"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
-        /
-        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
+        sloth_service="myservice2", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
+        sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam2

--- a/examples/_gen/k8s-multifile.yml
+++ b/examples/_gen/k8s-multifile.yml
@@ -114,10 +114,10 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+    - expr: |-
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam
@@ -373,10 +373,10 @@ spec:
         sloth_window: 3d
         tier: "1"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"}[30d])
+    - expr: |-
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam2

--- a/examples/_gen/k8s-multifile.yml
+++ b/examples/_gen/k8s-multifile.yml
@@ -114,9 +114,10 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-        sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-        sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    - expr: |
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam
@@ -372,9 +373,10 @@ spec:
         sloth_window: 3d
         tier: "1"
       record: slo:sli_error:ratio_rate3d
-    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
-        sloth_service="myservice2", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
-        sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+    - expr: |
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam2

--- a/examples/_gen/k8s-multifile.yml
+++ b/examples/_gen/k8s-multifile.yml
@@ -114,7 +114,7 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |-
+    - expr: |
         sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
         /
         count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
@@ -373,7 +373,7 @@ spec:
         sloth_window: 3d
         tier: "1"
       record: slo:sli_error:ratio_rate3d
-    - expr: |-
+    - expr: |
         sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
         /
         count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])

--- a/examples/_gen/kubernetes-apiserver.yml
+++ b/examples/_gen/kubernetes-apiserver.yml
@@ -105,7 +105,7 @@ groups:
       sloth_slo: requests-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
@@ -385,7 +385,7 @@ groups:
       sloth_slo: requests-latency
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])

--- a/examples/_gen/kubernetes-apiserver.yml
+++ b/examples/_gen/kubernetes-apiserver.yml
@@ -105,10 +105,10 @@ groups:
       sloth_slo: requests-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability",
+      sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:]) /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability",
+      sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
     labels:
       category: availability
       cluster: valhalla
@@ -385,10 +385,9 @@ groups:
       sloth_slo: requests-latency
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency",
+      sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency",
+      sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
     labels:
       category: latency
       cluster: valhalla

--- a/examples/_gen/kubernetes-apiserver.yml
+++ b/examples/_gen/kubernetes-apiserver.yml
@@ -105,10 +105,10 @@ groups:
       sloth_slo: requests-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
     labels:
       category: availability
       cluster: valhalla
@@ -385,10 +385,10 @@ groups:
       sloth_slo: requests-latency
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
     labels:
       category: latency
       cluster: valhalla

--- a/examples/_gen/kubernetes-apiserver.yml
+++ b/examples/_gen/kubernetes-apiserver.yml
@@ -105,10 +105,10 @@ groups:
       sloth_slo: requests-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability",
-      sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:]) /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability",
-      sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability", sloth_service="k8s-apiserver", sloth_slo="requests-availability"})[30d:])
     labels:
       category: availability
       cluster: valhalla
@@ -385,9 +385,10 @@ groups:
       sloth_slo: requests-latency
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency",
-      sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency",
-      sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency", sloth_service="k8s-apiserver", sloth_slo="requests-latency"})[30d:])
     labels:
       category: latency
       cluster: valhalla

--- a/examples/_gen/multifile.yml
+++ b/examples/_gen/multifile.yml
@@ -105,9 +105,10 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-      sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-      sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam
@@ -353,9 +354,10 @@ groups:
       sloth_window: 3d
       tier: "1"
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
-      sloth_service="myservice2", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
-      sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam2

--- a/examples/_gen/multifile.yml
+++ b/examples/_gen/multifile.yml
@@ -105,7 +105,7 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
@@ -354,7 +354,7 @@ groups:
       sloth_window: 3d
       tier: "1"
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])

--- a/examples/_gen/multifile.yml
+++ b/examples/_gen/multifile.yml
@@ -105,10 +105,10 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam
@@ -354,10 +354,10 @@ groups:
       sloth_window: 3d
       tier: "1"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam2

--- a/examples/_gen/multifile.yml
+++ b/examples/_gen/multifile.yml
@@ -105,10 +105,9 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+      sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+      sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam
@@ -354,10 +353,9 @@ groups:
       sloth_window: 3d
       tier: "1"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability", sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
+      sloth_service="myservice2", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice2-requests-availability",
+      sloth_service="myservice2", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam2

--- a/examples/_gen/no-alerts.yml
+++ b/examples/_gen/no-alerts.yml
@@ -133,10 +133,10 @@ groups:
       sloth_slo: http-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/no-alerts.yml
+++ b/examples/_gen/no-alerts.yml
@@ -133,10 +133,9 @@ groups:
       sloth_slo: http-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability",
+      sloth_service="myapp", sloth_slo="http-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability",
+      sloth_service="myapp", sloth_slo="http-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/no-alerts.yml
+++ b/examples/_gen/no-alerts.yml
@@ -133,9 +133,10 @@ groups:
       sloth_slo: http-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability",
-      sloth_service="myapp", sloth_slo="http-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability",
-      sloth_service="myapp", sloth_slo="http-availability"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/no-alerts.yml
+++ b/examples/_gen/no-alerts.yml
@@ -133,7 +133,7 @@ groups:
       sloth_slo: http-availability
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myapp-http-availability", sloth_service="myapp", sloth_slo="http-availability"})[30d:])

--- a/examples/_gen/openslo-getting-started.yml
+++ b/examples/_gen/openslo-getting-started.yml
@@ -140,10 +140,10 @@ groups:
       sloth_slo: sloth-slo-my-service-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: my-service-sloth-slo-my-service-0

--- a/examples/_gen/openslo-getting-started.yml
+++ b/examples/_gen/openslo-getting-started.yml
@@ -140,7 +140,7 @@ groups:
       sloth_slo: sloth-slo-my-service-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])

--- a/examples/_gen/openslo-getting-started.yml
+++ b/examples/_gen/openslo-getting-started.yml
@@ -140,10 +140,9 @@ groups:
       sloth_slo: sloth-slo-my-service-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0",
+      sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0",
+      sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: my-service-sloth-slo-my-service-0

--- a/examples/_gen/openslo-getting-started.yml
+++ b/examples/_gen/openslo-getting-started.yml
@@ -140,9 +140,10 @@ groups:
       sloth_slo: sloth-slo-my-service-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0",
-      sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0",
-      sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="my-service-sloth-slo-my-service-0", sloth_service="my-service", sloth_slo="sloth-slo-my-service-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: my-service-sloth-slo-my-service-0

--- a/examples/_gen/openslo-kubernetes-apiserver.yml
+++ b/examples/_gen/openslo-kubernetes-apiserver.yml
@@ -140,7 +140,7 @@ groups:
       sloth_slo: requests-availability-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
@@ -354,7 +354,7 @@ groups:
       sloth_slo: requests-latency-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
@@ -562,7 +562,7 @@ groups:
       sloth_slo: requests-latency-openslo-1
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])

--- a/examples/_gen/openslo-kubernetes-apiserver.yml
+++ b/examples/_gen/openslo-kubernetes-apiserver.yml
@@ -140,10 +140,10 @@ groups:
       sloth_slo: requests-availability-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-availability-openslo-0
@@ -354,10 +354,10 @@ groups:
       sloth_slo: requests-latency-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-latency-openslo-0
@@ -562,10 +562,10 @@ groups:
       sloth_slo: requests-latency-openslo-1
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-latency-openslo-1

--- a/examples/_gen/openslo-kubernetes-apiserver.yml
+++ b/examples/_gen/openslo-kubernetes-apiserver.yml
@@ -140,10 +140,10 @@ groups:
       sloth_slo: requests-availability-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0",
-      sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
-      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0",
-      sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-availability-openslo-0
@@ -354,10 +354,10 @@ groups:
       sloth_slo: requests-latency-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0",
-      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
-      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0",
-      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-latency-openslo-0
@@ -562,10 +562,10 @@ groups:
       sloth_slo: requests-latency-openslo-1
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1",
-      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
-      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1",
-      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-latency-openslo-1

--- a/examples/_gen/openslo-kubernetes-apiserver.yml
+++ b/examples/_gen/openslo-kubernetes-apiserver.yml
@@ -140,10 +140,10 @@ groups:
       sloth_slo: requests-availability-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0",
+      sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
+      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-availability-openslo-0",
+      sloth_service="k8s-apiserver", sloth_slo="requests-availability-openslo-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-availability-openslo-0
@@ -354,10 +354,10 @@ groups:
       sloth_slo: requests-latency-openslo-0
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0",
+      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
+      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-0",
+      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-0"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-latency-openslo-0
@@ -562,10 +562,10 @@ groups:
       sloth_slo: requests-latency-openslo-1
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1", sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1",
+      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
+      / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="k8s-apiserver-requests-latency-openslo-1",
+      sloth_service="k8s-apiserver", sloth_slo="requests-latency-openslo-1"})[30d:])
     labels:
       cmd: examplesgen.sh
       sloth_id: k8s-apiserver-requests-latency-openslo-1

--- a/examples/_gen/plugin-getting-started.yml
+++ b/examples/_gen/plugin-getting-started.yml
@@ -112,9 +112,10 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-      sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-      sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/plugin-getting-started.yml
+++ b/examples/_gen/plugin-getting-started.yml
@@ -112,10 +112,10 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/plugin-getting-started.yml
+++ b/examples/_gen/plugin-getting-started.yml
@@ -112,7 +112,7 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])

--- a/examples/_gen/plugin-getting-started.yml
+++ b/examples/_gen/plugin-getting-started.yml
@@ -112,10 +112,9 @@ groups:
       sloth_window: 3d
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+      sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+      sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
     labels:
       cmd: examplesgen.sh
       owner: myteam

--- a/examples/_gen/plugin-k8s-getting-started.yml
+++ b/examples/_gen/plugin-k8s-getting-started.yml
@@ -124,10 +124,9 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
-        /
-        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+        sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
+        sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam

--- a/examples/_gen/plugin-k8s-getting-started.yml
+++ b/examples/_gen/plugin-k8s-getting-started.yml
@@ -124,7 +124,7 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |-
+    - expr: |
         sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
         /
         count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])

--- a/examples/_gen/plugin-k8s-getting-started.yml
+++ b/examples/_gen/plugin-k8s-getting-started.yml
@@ -124,10 +124,10 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"}[30d])
+    - expr: |-
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam

--- a/examples/_gen/plugin-k8s-getting-started.yml
+++ b/examples/_gen/plugin-k8s-getting-started.yml
@@ -124,9 +124,10 @@ spec:
         sloth_window: 3d
         tier: "2"
       record: slo:sli_error:ratio_rate3d
-    - expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-        sloth_service="myservice", sloth_slo="requests-availability"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability",
-        sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+    - expr: |
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="myservice-requests-availability", sloth_service="myservice", sloth_slo="requests-availability"})[30d:])
       labels:
         cmd: examplesgen.sh
         owner: myteam

--- a/examples/_gen/raw-home-wifi.yml
+++ b/examples/_gen/raw-home-wifi.yml
@@ -126,10 +126,10 @@ groups:
       sloth_slo: wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"}[30d])
+    expr: |-
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh

--- a/examples/_gen/raw-home-wifi.yml
+++ b/examples/_gen/raw-home-wifi.yml
@@ -126,10 +126,9 @@ groups:
       sloth_slo: wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
-      /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
+    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction",
+      sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction",
+      sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh

--- a/examples/_gen/raw-home-wifi.yml
+++ b/examples/_gen/raw-home-wifi.yml
@@ -126,9 +126,10 @@ groups:
       sloth_slo: wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: aa sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction",
-      sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:]) / count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction",
-      sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
+    expr: |
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
     labels:
       cluster: valhalla
       cmd: examplesgen.sh

--- a/examples/_gen/raw-home-wifi.yml
+++ b/examples/_gen/raw-home-wifi.yml
@@ -126,7 +126,7 @@ groups:
       sloth_slo: wifi-client-satisfaction
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
-    expr: |-
+    expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="home-wifi-wifi-client-satisfaction", sloth_service="home-wifi", sloth_slo="wifi-client-satisfaction"})[30d:])

--- a/internal/app/generate/prometheus_test.go
+++ b/internal/app/generate/prometheus_test.go
@@ -226,7 +226,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 								},
 								{
 									Record: "slo:sli_error:ratio_rate30d",
-                  Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
+									Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 									Labels: map[string]string{
 										"test_label":    "label_1",
 										"extra_k1":      "extra_v1",

--- a/internal/app/generate/prometheus_test.go
+++ b/internal/app/generate/prometheus_test.go
@@ -226,7 +226,7 @@ func TestIntegrationAppServiceGenerate(t *testing.T) {
 								},
 								{
 									Record: "slo:sli_error:ratio_rate30d",
-									Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+                  Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test-id\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 									Labels: map[string]string{
 										"test_label":    "label_1",
 										"extra_k1":      "extra_v1",

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -155,7 +155,8 @@ func optimizedSLIRecordGenerator(slo SLO, window, shortWindow time.Duration) (*r
 	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
 	const sliExprTplFmt = `sum_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
 /
-count_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])`
+count_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
+`
 
 	if window == shortWindow {
 		return nil, fmt.Errorf("can't optimize using the same shortwindow as the window to optimize")

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -155,8 +155,7 @@ func optimizedSLIRecordGenerator(slo SLO, window, shortWindow time.Duration) (*r
 	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
 	const sliExprTplFmt = `sum_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
 /
-count_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
-`
+count_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])`
 
 	if window == shortWindow {
 		return nil, fmt.Errorf("can't optimize using the same shortwindow as the window to optimize")

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -153,7 +153,7 @@ func optimizedSLIRecordGenerator(slo SLO, window, shortWindow time.Duration) (*r
 	// that is 1 (thats why we can use `count`), giving use a correct ratio of ratios:
 	// - https://prometheus.io/docs/practices/rules/
 	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
-  const sliExprTplFmt = `sum_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
+	const sliExprTplFmt = `sum_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
 /
 count_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
 `

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -153,9 +153,9 @@ func optimizedSLIRecordGenerator(slo SLO, window, shortWindow time.Duration) (*r
 	// that is 1 (thats why we can use `count`), giving use a correct ratio of ratios:
 	// - https://prometheus.io/docs/practices/rules/
 	// - https://math.stackexchange.com/questions/95909/why-is-an-average-of-an-average-usually-incorrect
-	const sliExprTplFmt = `sum_over_time({{.metric}}{{.filter}}[{{.window}}])
-/ ignoring ({{.windowKey}})
-count_over_time({{.metric}}{{.filter}}[{{.window}}])
+  const sliExprTplFmt = `sum_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
+/
+count_over_time(sum({{.metric}}{{.filter}})[{{.window}}:])
 `
 
 	if window == shortWindow {

--- a/internal/prometheus/recording_rules_test.go
+++ b/internal/prometheus/recording_rules_test.go
@@ -186,7 +186,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+          Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -405,7 +405,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+          Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -476,7 +476,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-					Expr:   "sum_over_time(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"}[30d])\n",
+          Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",

--- a/internal/prometheus/recording_rules_test.go
+++ b/internal/prometheus/recording_rules_test.go
@@ -186,7 +186,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-          Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
+					Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -405,7 +405,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-          Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
+					Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",
@@ -476,7 +476,7 @@ func TestGenerateSLIRecordingRules(t *testing.T) {
 				},
 				{
 					Record: "slo:sli_error:ratio_rate30d",
-          Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
+					Expr:   "sum_over_time(sum(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate3h{sloth_id=\"test\", sloth_service=\"test-svc\", sloth_slo=\"test-name\"})[30d:])\n",
 					Labels: map[string]string{
 						"kind":          "test",
 						"sloth_service": "test-svc",

--- a/test/integration/k8scontroller/exp_base_28d_test.go
+++ b/test/integration/k8scontroller/exp_base_28d_test.go
@@ -114,7 +114,7 @@ func getBase28DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometh
 						},
 						{
 							Record: "slo:sli_error:ratio_rate4w",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[4w])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[4w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[4w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[4w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -326,7 +326,7 @@ func getBase28DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometh
 						},
 						{
 							Record: "slo:sli_error:ratio_rate4w",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[4w])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[4w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[4w])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_28d_test.go
+++ b/test/integration/k8scontroller/exp_base_28d_test.go
@@ -326,7 +326,7 @@ func getBase28DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometh
 						},
 						{
 							Record: "slo:sli_error:ratio_rate4w",
-							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[4w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_28d_test.go
+++ b/test/integration/k8scontroller/exp_base_28d_test.go
@@ -114,7 +114,7 @@ func getBase28DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometh
 						},
 						{
 							Record: "slo:sli_error:ratio_rate4w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[4w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[4w:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[4w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[4w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -326,7 +326,7 @@ func getBase28DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometh
 						},
 						{
 							Record: "slo:sli_error:ratio_rate4w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[4w])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[4w])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_28d_test.go
+++ b/test/integration/k8scontroller/exp_base_28d_test.go
@@ -326,7 +326,7 @@ func getBase28DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometh
 						},
 						{
 							Record: "slo:sli_error:ratio_rate4w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[4w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_7d_test.go
+++ b/test/integration/k8scontroller/exp_base_7d_test.go
@@ -114,7 +114,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -326,7 +326,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_7d_test.go
+++ b/test/integration/k8scontroller/exp_base_7d_test.go
@@ -114,7 +114,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[1w])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[1w])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -326,7 +326,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[1w])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[1w])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_7d_test.go
+++ b/test/integration/k8scontroller/exp_base_7d_test.go
@@ -114,7 +114,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[1w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -326,7 +326,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[1w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_7d_test.go
+++ b/test/integration/k8scontroller/exp_base_7d_test.go
@@ -114,7 +114,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[1w])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[1w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[1w])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -326,7 +326,7 @@ func getBase7DayPromOpPrometheusRule(slothVersion string) *monitoringv1.Promethe
 						},
 						{
 							Record: "slo:sli_error:ratio_rate1w",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[1w])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[1w])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[1w:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[1w])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_test.go
+++ b/test/integration/k8scontroller/exp_base_test.go
@@ -383,7 +383,7 @@ func getBasePromOpPrometheusRule(slothVersion string) *monitoringv1.PrometheusRu
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_test.go
+++ b/test/integration/k8scontroller/exp_base_test.go
@@ -171,7 +171,7 @@ func getBasePromOpPrometheusRule(slothVersion string) *monitoringv1.PrometheusRu
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[30d])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -383,7 +383,7 @@ func getBasePromOpPrometheusRule(slothVersion string) *monitoringv1.PrometheusRu
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[30d])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[30d])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_test.go
+++ b/test/integration/k8scontroller/exp_base_test.go
@@ -171,7 +171,7 @@ func getBasePromOpPrometheusRule(slothVersion string) *monitoringv1.PrometheusRu
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"slo01k1":       "slo01v1",
@@ -383,7 +383,7 @@ func getBasePromOpPrometheusRule(slothVersion string) *monitoringv1.PrometheusRu
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[30d])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[30d])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_base_test.go
+++ b/test/integration/k8scontroller/exp_base_test.go
@@ -383,7 +383,7 @@ func getBasePromOpPrometheusRule(slothVersion string) *monitoringv1.PrometheusRu
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"}[30d])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo02\", sloth_service=\"svc01\", sloth_slo=\"slo02\"})[30d:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"sloth_id":      "svc01-slo02",

--- a/test/integration/k8scontroller/exp_plugin_test.go
+++ b/test/integration/k8scontroller/exp_plugin_test.go
@@ -169,7 +169,7 @@ func getPluginPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometheus
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n"),
+							Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"owner":         "myteam",

--- a/test/integration/k8scontroller/exp_plugin_test.go
+++ b/test/integration/k8scontroller/exp_plugin_test.go
@@ -169,7 +169,7 @@ func getPluginPromOpPrometheusRule(slothVersion string) *monitoringv1.Prometheus
 						},
 						{
 							Record: "slo:sli_error:ratio_rate30d",
-							Expr:   intstr.FromString("sum_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[30d])\n/ ignoring (sloth_window)\ncount_over_time(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"}[30d])\n"),
+              Expr:   intstr.FromString("sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n/\ncount_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id=\"svc01-slo01\", sloth_service=\"svc01\", sloth_slo=\"slo01\"})[30d:])\n"),
 							Labels: map[string]string{
 								"globalk1":      "globalv1",
 								"owner":         "myteam",

--- a/test/integration/prometheus/testdata/out-base-28d.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-28d.yaml.tpl
@@ -92,9 +92,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate4w
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[4w])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[4w])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[4w:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[4w:])
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -314,9 +314,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate4w
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[4w])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[4w])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[4w:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[4w:])
     labels:
       global01k1: global01v1
       global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-base-custom-windows-7d.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-custom-windows-7d.yaml.tpl
@@ -92,9 +92,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate1w
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[1w])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[1w])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[1w:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[1w:])
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -314,9 +314,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate1w
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[1w])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[1w])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[1w:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[1w:])
     labels:
       global01k1: global01v1
       global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-base-extra-labels.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-extra-labels.yaml.tpl
@@ -106,9 +106,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
     labels:
       exk1: exv1
       exk2: exv2
@@ -358,9 +358,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
     labels:
       exk1: exv1
       exk2: exv2

--- a/test/integration/prometheus/testdata/out-base-k8s.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-k8s.yaml.tpl
@@ -101,9 +101,9 @@ spec:
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
     - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -323,9 +323,9 @@ spec:
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
     - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
       labels:
         global01k1: global01v1
         global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-base-no-alerts.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-no-alerts.yaml.tpl
@@ -94,7 +94,7 @@ groups:
     expr: |
       sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
       /
-      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1")}[30d:])
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
     labels:
       global01k1: global01v1
       global02k1: global02v1

--- a/test/integration/prometheus/testdata/out-base-no-alerts.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base-no-alerts.yaml.tpl
@@ -92,9 +92,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1")}[30d:])
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -266,9 +266,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
     labels:
       global01k1: global01v1
       global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-base.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base.yaml.tpl
@@ -92,9 +92,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -314,9 +314,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
     labels:
       global01k1: global01v1
       global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-base.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-base.yaml.tpl
@@ -314,7 +314,7 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
       /
       count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
     labels:

--- a/test/integration/prometheus/testdata/out-multifile-k8s.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-multifile-k8s.yaml.tpl
@@ -101,9 +101,9 @@ spec:
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
     - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -323,9 +323,9 @@ spec:
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
     - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
       labels:
         global01k1: global01v1
         global03k1: global03v1
@@ -506,9 +506,9 @@ spec:
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
     - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"}[30d])
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"})[30d:])
       labels:
         global01k1: global01v1
         global02k1: global02v1
@@ -728,9 +728,9 @@ spec:
         sloth_window: 3d
       record: slo:sli_error:ratio_rate3d
     - expr: |
-        sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"}[30d])
-        / ignoring (sloth_window)
-        count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"}[30d])
+        sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"})[30d:])
+        /
+        count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"})[30d:])
       labels:
         global01k1: global01v1
         global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-multifile.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-multifile.yaml.tpl
@@ -92,9 +92,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -314,9 +314,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo02", sloth_service="svc01", sloth_slo="slo02"})[30d:])
     labels:
       global01k1: global01v1
       global03k1: global03v1
@@ -487,9 +487,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo1", sloth_service="svc02", sloth_slo="slo1"})[30d:])
     labels:
       global01k1: global01v1
       global02k1: global02v1
@@ -709,9 +709,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc02-slo02", sloth_service="svc02", sloth_slo="slo02"})[30d:])
     labels:
       global01k1: global01v1
       global03k1: global03v1

--- a/test/integration/prometheus/testdata/out-openslo.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-openslo.yaml.tpl
@@ -134,9 +134,9 @@ groups:
       sloth_window: 3d
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1-0", sloth_service="svc01", sloth_slo="slo1-0"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1-0", sloth_service="svc01", sloth_slo="slo1-0"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1-0", sloth_service="svc01", sloth_slo="slo1-0"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1-0", sloth_service="svc01", sloth_slo="slo1-0"})[30d:])
     labels:
       sloth_id: svc01-slo1-0
       sloth_service: svc01

--- a/test/integration/prometheus/testdata/out-plugin.yaml.tpl
+++ b/test/integration/prometheus/testdata/out-plugin.yaml.tpl
@@ -99,9 +99,9 @@ groups:
       tier: "2"
   - record: slo:sli_error:ratio_rate30d
     expr: |
-      sum_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
-      / ignoring (sloth_window)
-      count_over_time(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"}[30d])
+      sum_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
+      /
+      count_over_time(sum(slo:sli_error:ratio_rate5m{sloth_id="svc01-slo1", sloth_service="svc01", sloth_slo="slo1"})[30d:])
     labels:
       owner: myteam
       sloth_id: svc01-slo1


### PR DESCRIPTION
This PR fixes the following problem:

You define an SLO with label `mylabel=original`. Let that run for a while. Then you change the label to `mylabel=changed`. This will cause the `slo:sli_error:ratio_rate<window>` to fail for the duration of the window with the error `vector contains metrics with the same labelset after applying rule labels`.

To fix this problem we essentially discard the labels from the query. They are then re-applied to the resulting recording rule.