### PR TITLE
misc: update golangci-lint and use cached action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,11 +6,16 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    # Execute the checks inside the container instead the VM.
-    container: golangci/golangci-lint:v1.50.0-alpine
+    # TODO: Consider moving this to a separate job to prevent parallel execution
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/check/check.sh
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
 
   unit-test:
     name: Unit test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,3 +11,11 @@ linters:
     - revive
     - gofmt
     - godot
+
+issues:
+  exclude-rules:
+    # Exclude unused parameter checks from the noop logger for readability
+    - path: internal/log/log.go
+      linters:
+        - revive
+      text: "unused-parameter: parameter '(\\w+)' seems to be unused, .*"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,5 +10,4 @@ linters:
     - goimports
     - revive
     - gofmt
-    - depguard
     - godot

--- a/cmd/sloth/commands/helpers.go
+++ b/cmd/sloth/commands/helpers.go
@@ -38,7 +38,7 @@ func splitYAML(data []byte) []string {
 	return nonEmptyData
 }
 
-func createPluginLoader(ctx context.Context, logger log.Logger, paths []string) (*prometheus.FileSLIPluginRepo, error) {
+func createPluginLoader(_ context.Context, logger log.Logger, paths []string) (*prometheus.FileSLIPluginRepo, error) {
 	config := prometheus.FileSLIPluginRepoConfig{
 		Paths:  paths,
 		Logger: logger,

--- a/cmd/sloth/commands/k8scontroller.go
+++ b/cmd/sloth/commands/k8scontroller.go
@@ -164,7 +164,7 @@ func (k kubeControllerCommand) Run(ctx context.Context, config RootConfig) error
 	// Run hot-reload.
 	{
 		// Set SLI plugin repository reloader.
-		reloadManager.Add(1000, reload.ReloaderFunc(func(ctx context.Context, id string) error {
+		reloadManager.Add(1000, reload.ReloaderFunc(func(ctx context.Context, _ string) error {
 			return pluginRepo.Reload(ctx)
 		}))
 
@@ -189,7 +189,7 @@ func (k kubeControllerCommand) Run(ctx context.Context, config RootConfig) error
 		signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 
 		// Add hot-reload notifier for SIGHUP.
-		reloadManager.On(reload.NotifierFunc(func(ctx context.Context) (string, error) {
+		reloadManager.On(reload.NotifierFunc(func(_ context.Context) (string, error) {
 			<-reloadC
 			logger.Infof("Hot-reload triggered from OS SIGHUP signal")
 			return "sighup", nil
@@ -225,7 +225,7 @@ func (k kubeControllerCommand) Run(ctx context.Context, config RootConfig) error
 	{
 		// Set reloader signaler.
 		hotReloadC := make(chan struct{})
-		reloadManager.On(reload.NotifierFunc(func(ctx context.Context) (string, error) {
+		reloadManager.On(reload.NotifierFunc(func(_ context.Context) (string, error) {
 			<-hotReloadC
 			logger.Infof("Hot-reload triggered from http webhook")
 			return "http", nil
@@ -384,7 +384,7 @@ type kubernetesService interface {
 	EnsurePrometheusServiceLevelStatus(ctx context.Context, slo *slothv1.PrometheusServiceLevel, err error) error
 }
 
-func (k kubeControllerCommand) newKubernetesService(ctx context.Context, config RootConfig) (kubernetesService, error) {
+func (k kubeControllerCommand) newKubernetesService(_ context.Context, config RootConfig) (kubernetesService, error) {
 	config.Logger.Infof("Loading Kubernetes configuration...")
 
 	// Fake mode.

--- a/cmd/sloth/commands/version.go
+++ b/cmd/sloth/commands/version.go
@@ -20,7 +20,7 @@ func NewVersionCommand(app *kingpin.Application) Command {
 }
 
 func (versionCommand) Name() string { return "version" }
-func (versionCommand) Run(ctx context.Context, config RootConfig) error {
-	fmt.Fprintf(config.Stdout, info.Version)
+func (versionCommand) Run(_ context.Context, config RootConfig) error {
+	fmt.Fprint(config.Stdout, info.Version)
 	return nil
 }

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.23.2
 
 LABEL org.opencontainers.image.source https://github.com/slok/sloth
 
-ARG GOLANGCI_LINT_VERSION="1.50.0"
+ARG GOLANGCI_LINT_VERSION="1.55.0"
 ARG MOCKERY_VERSION="2.14.0"
 ARG GOMARKDOC_VERSION="0.4.1"
 ARG HELM_VERSION="3.10.0"

--- a/internal/alert/window.go
+++ b/internal/alert/window.go
@@ -221,7 +221,7 @@ func (f *FSWindowsRepo) load(ctx context.Context, windowsFS fs.FS) error {
 	return nil
 }
 
-func (f *FSWindowsRepo) GetWindows(ctx context.Context, period time.Duration) (*Windows, error) {
+func (f *FSWindowsRepo) GetWindows(_ context.Context, period time.Duration) (*Windows, error) {
 	w, ok := f.windows[period]
 	if !ok {
 		return nil, fmt.Errorf("window period %s missing", period)
@@ -232,7 +232,7 @@ func (f *FSWindowsRepo) GetWindows(ctx context.Context, period time.Duration) (*
 
 type windowLoader struct{}
 
-func (l windowLoader) LoadWindow(ctx context.Context, data []byte) (*Windows, error) {
+func (l windowLoader) LoadWindow(_ context.Context, data []byte) (*Windows, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("spec is required")
 	}

--- a/internal/app/generate/noop.go
+++ b/internal/app/generate/noop.go
@@ -13,7 +13,7 @@ type noopSLIRecordingRulesGenerator bool
 
 const NoopSLIRecordingRulesGenerator = noopSLIRecordingRulesGenerator(false)
 
-func (noopSLIRecordingRulesGenerator) GenerateSLIRecordingRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (noopSLIRecordingRulesGenerator) GenerateSLIRecordingRules(_ context.Context, _ prometheus.SLO, _ alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	return nil, nil
 }
 
@@ -21,7 +21,7 @@ type noopMetadataRecordingRulesGenerator bool
 
 const NoopMetadataRecordingRulesGenerator = noopMetadataRecordingRulesGenerator(false)
 
-func (noopMetadataRecordingRulesGenerator) GenerateMetadataRecordingRules(ctx context.Context, info info.Info, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (noopMetadataRecordingRulesGenerator) GenerateMetadataRecordingRules(_ context.Context, _ info.Info, _ prometheus.SLO, _ alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	return nil, nil
 }
 
@@ -29,6 +29,6 @@ type noopSLOAlertRulesGenerator bool
 
 const NoopSLOAlertRulesGenerator = noopSLOAlertRulesGenerator(false)
 
-func (noopSLOAlertRulesGenerator) GenerateSLOAlertRules(ctx context.Context, slo prometheus.SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (noopSLOAlertRulesGenerator) GenerateSLOAlertRules(_ context.Context, _ prometheus.SLO, _ alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	return nil, nil
 }

--- a/internal/app/kubecontroller/handler.go
+++ b/internal/app/kubecontroller/handler.go
@@ -183,7 +183,7 @@ func (h handler) handlePrometheusServiceLevelV1(ctx context.Context, psl *slothv
 	return nil
 }
 
-func (h handler) ignoreHandlePrometheusServiceLevelV1(ctx context.Context, psl *slothv1.PrometheusServiceLevel) (reason string, ignore bool) {
+func (h handler) ignoreHandlePrometheusServiceLevelV1(_ context.Context, psl *slothv1.PrometheusServiceLevel) (reason string, ignore bool) {
 	// If the received object is being deleted, ignore.
 	deleteInProgress := !psl.DeletionTimestamp.IsZero()
 	if deleteInProgress {

--- a/internal/k8sprometheus/kubernetes.go
+++ b/internal/k8sprometheus/kubernetes.go
@@ -112,12 +112,12 @@ func (d DryRunKubernetesService) WatchPrometheusServiceLevels(ctx context.Contex
 	return d.svc.WatchPrometheusServiceLevels(ctx, ns, opts)
 }
 
-func (d DryRunKubernetesService) EnsurePrometheusRule(ctx context.Context, pr *monitoringv1.PrometheusRule) error {
+func (d DryRunKubernetesService) EnsurePrometheusRule(_ context.Context, _ *monitoringv1.PrometheusRule) error {
 	d.logger.Infof("Dry run EnsurePrometheusRule")
 	return nil
 }
 
-func (d DryRunKubernetesService) EnsurePrometheusServiceLevelStatus(ctx context.Context, slo *slothv1.PrometheusServiceLevel, err error) error {
+func (d DryRunKubernetesService) EnsurePrometheusServiceLevelStatus(_ context.Context, _ *slothv1.PrometheusServiceLevel, _ error) error {
 	d.logger.Infof("Dry run EnsurePrometheusServiceLevelStatus")
 	return nil
 }

--- a/internal/k8sprometheus/spec.go
+++ b/internal/k8sprometheus/spec.go
@@ -39,7 +39,7 @@ var (
 	specTypeV1RegexAPIVersion = regexp.MustCompile(`(?m)^apiVersion: +['"]?sloth.slok.dev\/v1['"]? *$`)
 )
 
-func (y YAMLSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
+func (y YAMLSpecLoader) IsSpecType(_ context.Context, data []byte) bool {
 	return specTypeV1RegexKind.Match(data) && specTypeV1RegexAPIVersion.Match(data)
 }
 

--- a/internal/k8sprometheus/spec_test.go
+++ b/internal/k8sprometheus/spec_test.go
@@ -14,7 +14,7 @@ import (
 
 type testMemPluginsRepo map[string]prometheus.SLIPlugin
 
-func (t testMemPluginsRepo) GetSLIPlugin(ctx context.Context, id string) (*prometheus.SLIPlugin, error) {
+func (t testMemPluginsRepo) GetSLIPlugin(_ context.Context, id string) (*prometheus.SLIPlugin, error) {
 	p, ok := t[id]
 	if !ok {
 		return nil, fmt.Errorf("unknown plugin")
@@ -117,7 +117,7 @@ spec:
 			plugins: map[string]prometheus.SLIPlugin{
 				"test_plugin": {
 					ID: "test_plugin",
-					Func: func(ctx context.Context, meta map[string]string, labels map[string]string, options map[string]string) (string, error) {
+					Func: func(_ context.Context, meta map[string]string, labels map[string]string, options map[string]string) (string, error) {
 						return fmt.Sprintf(`plugin_raw_expr{service="%s",slo="%s",objective="%s",gk1="%s",k1="%s",k2="%s"}`,
 							meta["service"],
 							meta["slo"],
@@ -185,7 +185,7 @@ spec:
 			plugins: map[string]prometheus.SLIPlugin{
 				"test_plugin": {
 					ID: "test_plugin",
-					Func: func(ctx context.Context, meta map[string]string, labels map[string]string, options map[string]string) (string, error) {
+					Func: func(_ context.Context, _ map[string]string, _ map[string]string, _ map[string]string) (string, error) {
 						return "", fmt.Errorf("something")
 					},
 				},
@@ -423,8 +423,8 @@ kind: 'PrometheusServiceLevel'
 
 		"An correct spec type should match (multiple spaces)": {
 			specYaml: `
-apiVersion:       sloth.slok.dev/v1           
-kind:               PrometheusServiceLevel      
+apiVersion:       sloth.slok.dev/v1
+kind:               PrometheusServiceLevel
 `,
 			exp: true,
 		},

--- a/internal/k8sprometheus/storage.go
+++ b/internal/k8sprometheus/storage.go
@@ -67,7 +67,7 @@ func (i IOWriterPrometheusOperatorYAMLRepo) StoreSLOs(ctx context.Context, kmeta
 	return nil
 }
 
-func mapModelToPrometheusOperator(ctx context.Context, kmeta K8sMeta, slos []StorageSLO) (*monitoringv1.PrometheusRule, error) {
+func mapModelToPrometheusOperator(_ context.Context, kmeta K8sMeta, slos []StorageSLO) (*monitoringv1.PrometheusRule, error) {
 	// Add extra labels.
 	labels := map[string]string{
 		"app.kubernetes.io/component":  "SLO",

--- a/internal/k8sprometheus/storage_test.go
+++ b/internal/k8sprometheus/storage_test.go
@@ -375,7 +375,7 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 		"Having 0 SLO rules should fail.": {
 			k8sMeta: k8sprometheus.K8sMeta{},
 			slos:    []k8sprometheus.StorageSLO{},
-			mock:    func(m *k8sprometheusmock.PrometheusRulesEnsurer) {},
+			mock:    func(_ *k8sprometheusmock.PrometheusRulesEnsurer) {},
 			expErr:  true,
 		},
 
@@ -384,7 +384,7 @@ func TestPrometheusOperatorCRDRepo(t *testing.T) {
 			slos: []k8sprometheus.StorageSLO{
 				{},
 			},
-			mock:   func(m *k8sprometheusmock.PrometheusRulesEnsurer) {},
+			mock:   func(_ *k8sprometheusmock.PrometheusRulesEnsurer) {},
 			expErr: true,
 		},
 

--- a/internal/openslo/spec.go
+++ b/internal/openslo/spec.go
@@ -31,11 +31,11 @@ var (
 	specTypeV1AlphaRegexAPIVersion = regexp.MustCompile(`(?m)^apiVersion: +['"]?openslo\/v1alpha['"]? *$`)
 )
 
-func (y YAMLSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
+func (y YAMLSpecLoader) IsSpecType(_ context.Context, data []byte) bool {
 	return specTypeV1AlphaRegexKind.Match(data) && specTypeV1AlphaRegexAPIVersion.Match(data)
 }
 
-func (y YAMLSpecLoader) LoadSpec(ctx context.Context, data []byte) (*prometheus.SLOGroup, error) {
+func (y YAMLSpecLoader) LoadSpec(_ context.Context, data []byte) (*prometheus.SLOGroup, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("spec is required")
 	}
@@ -114,7 +114,7 @@ var errorRatioRawQueryTpl = template.Must(template.New("").Parse(`
 // however we will convert to a raw based sloth SLI because the ratio queries that we have differ from
 // Sloth. Sloth uses bad/total events, OpenSLO uses good/total events. We get the ratio using good events
 // and then rest to 1, to get a raw error ratio query.
-func (y YAMLSpecLoader) getSLI(spec openslov1alpha.SLOSpec, slo openslov1alpha.Objective) (*prometheus.SLI, error) {
+func (y YAMLSpecLoader) getSLI(_ openslov1alpha.SLOSpec, slo openslov1alpha.Objective) (*prometheus.SLI, error) {
 	if slo.RatioMetrics == nil {
 		return nil, fmt.Errorf("missing ratioMetrics")
 	}

--- a/internal/prometheus/alert_rules.go
+++ b/internal/prometheus/alert_rules.go
@@ -22,7 +22,7 @@ type sloAlertRulesGenerator struct {
 // from an SLO.
 var SLOAlertRulesGenerator = sloAlertRulesGenerator{alertGenFunc: defaultSLOAlertGenerator}
 
-func (s sloAlertRulesGenerator) GenerateSLOAlertRules(ctx context.Context, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (s sloAlertRulesGenerator) GenerateSLOAlertRules(_ context.Context, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	rules := []rulefmt.Rule{}
 
 	// Generate Page alerts.

--- a/internal/prometheus/recording_rules.go
+++ b/internal/prometheus/recording_rules.go
@@ -40,7 +40,7 @@ func optimizedFactorySLIRecordGenerator(slo SLO, window time.Duration, alerts al
 	return factorySLIRecordGenerator(slo, window, alerts)
 }
 
-func (s sliRecordingRulesGenerator) GenerateSLIRecordingRules(ctx context.Context, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (s sliRecordingRulesGenerator) GenerateSLIRecordingRules(_ context.Context, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	// Get the windows we need the recording rules.
 	windows := getAlertGroupWindows(alerts)
 	windows = append(windows, slo.TimeWindow) // Add the total time window as a handy helper.
@@ -77,7 +77,7 @@ func factorySLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBA
 	return nil, fmt.Errorf("invalid SLI type")
 }
 
-func rawSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
+func rawSLIRecordGenerator(slo SLO, window time.Duration, _ alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
 	// Render with our templated data.
 	sliExprTpl := fmt.Sprintf(`(%s)`, slo.SLI.Raw.ErrorRatioQuery)
 	tpl, err := template.New("sliExpr").Option("missingkey=error").Parse(sliExprTpl)
@@ -107,7 +107,7 @@ func rawSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlert
 	}, nil
 }
 
-func eventsSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
+func eventsSLIRecordGenerator(slo SLO, window time.Duration, _ alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
 	const sliExprTplFmt = `(%s)
 /
 (%s)
@@ -143,7 +143,7 @@ func eventsSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAl
 	}, nil
 }
 
-func denominatorCorrectedSLIRecordGenerator(slo SLO, window time.Duration, alerts alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
+func denominatorCorrectedSLIRecordGenerator(slo SLO, window time.Duration, _ alert.MWMBAlertGroup) (*rulefmt.Rule, error) {
 	var sliExprTpl string
 
 	if slo.SLI.DenominatorCorrected.ErrorQuery != nil {
@@ -262,7 +262,7 @@ type metadataRecordingRulesGenerator bool
 // from an SLO.
 const MetadataRecordingRulesGenerator = metadataRecordingRulesGenerator(false)
 
-func (m metadataRecordingRulesGenerator) GenerateMetadataRecordingRules(ctx context.Context, info info.Info, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
+func (m metadataRecordingRulesGenerator) GenerateMetadataRecordingRules(_ context.Context, info info.Info, slo SLO, alerts alert.MWMBAlertGroup) ([]rulefmt.Rule, error) {
 	labels := mergeLabels(slo.GetSLOIDPromLabels(), slo.Labels)
 
 	// Metatada Recordings.

--- a/internal/prometheus/sli_plugin.go
+++ b/internal/prometheus/sli_plugin.go
@@ -27,7 +27,7 @@ type FileManager interface {
 
 type fileManager struct{}
 
-func (f fileManager) FindFiles(ctx context.Context, root string, matcher *regexp.Regexp) ([]string, error) {
+func (f fileManager) FindFiles(_ context.Context, root string, matcher *regexp.Regexp) ([]string, error) {
 	paths := []string{}
 	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
 		if err != nil {
@@ -174,14 +174,14 @@ func (f *FileSLIPluginRepo) Reload(ctx context.Context) error {
 	return nil
 }
 
-func (f *FileSLIPluginRepo) ListSLIPlugins(ctx context.Context) (map[string]SLIPlugin, error) {
+func (f *FileSLIPluginRepo) ListSLIPlugins(_ context.Context) (map[string]SLIPlugin, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
 	return f.plugins, nil
 }
 
-func (f *FileSLIPluginRepo) GetSLIPlugin(ctx context.Context, id string) (*SLIPlugin, error) {
+func (f *FileSLIPluginRepo) GetSLIPlugin(_ context.Context, id string) (*SLIPlugin, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 

--- a/internal/prometheus/spec.go
+++ b/internal/prometheus/spec.go
@@ -32,7 +32,7 @@ func NewYAMLSpecLoader(pluginsRepo SLIPluginRepo, windowPeriod time.Duration) YA
 
 var specTypeV1Regex = regexp.MustCompile(`(?m)^version: +['"]?prometheus\/v1['"]? *$`)
 
-func (y YAMLSpecLoader) IsSpecType(ctx context.Context, data []byte) bool {
+func (y YAMLSpecLoader) IsSpecType(_ context.Context, data []byte) bool {
 	return specTypeV1Regex.Match(data)
 }
 

--- a/internal/prometheus/spec_test.go
+++ b/internal/prometheus/spec_test.go
@@ -13,7 +13,7 @@ import (
 
 type testMemPluginsRepo map[string]prometheus.SLIPlugin
 
-func (t testMemPluginsRepo) GetSLIPlugin(ctx context.Context, id string) (*prometheus.SLIPlugin, error) {
+func (t testMemPluginsRepo) GetSLIPlugin(_ context.Context, id string) (*prometheus.SLIPlugin, error) {
 	p, ok := t[id]
 	if !ok {
 		return nil, fmt.Errorf("unknown plugin")
@@ -90,7 +90,7 @@ slos:
 			plugins: map[string]prometheus.SLIPlugin{
 				"test_plugin": {
 					ID: "test_plugin",
-					Func: func(ctx context.Context, meta map[string]string, labels map[string]string, options map[string]string) (string, error) {
+					Func: func(_ context.Context, _ map[string]string, _ map[string]string, _ map[string]string) (string, error) {
 						return "", fmt.Errorf("something")
 					},
 				},
@@ -118,7 +118,7 @@ slos:
 			plugins: map[string]prometheus.SLIPlugin{
 				"test_plugin": {
 					ID: "test_plugin",
-					Func: func(ctx context.Context, meta map[string]string, labels map[string]string, options map[string]string) (string, error) {
+					Func: func(_ context.Context, meta map[string]string, labels map[string]string, options map[string]string) (string, error) {
 						return fmt.Sprintf(`plugin_raw_expr{service="%s",slo="%s",objective="%s",gk1="%s",k1="%s",k2="%s"}`,
 							meta["service"],
 							meta["slo"],

--- a/test/integration/k8scontroller/helpers.go
+++ b/test/integration/k8scontroller/helpers.go
@@ -83,7 +83,7 @@ type KubeClients struct {
 }
 
 // NewKubernetesClients returns Kubernetes clients.
-func NewKubernetesClients(ctx context.Context, config Config) (*KubeClients, error) {
+func NewKubernetesClients(_ context.Context, config Config) (*KubeClients, error) {
 	kcfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{
 			ExplicitPath: config.KubeConfig,

--- a/test/integration/k8scontroller/plugin/plugin.go
+++ b/test/integration/k8scontroller/plugin/plugin.go
@@ -21,7 +21,7 @@ sum(rate(integration_test{ {{.filter}}job="{{.job}}" }[{{"{{.window}}"}}]))`))
 
 var filterRegex = regexp.MustCompile(`([^=]+="[^=,"]+",)+`)
 
-func SLIPlugin(ctx context.Context, meta, labels, options map[string]string) (string, error) {
+func SLIPlugin(_ context.Context, _, labels, options map[string]string) (string, error) {
 	// Get job.
 	job, ok := options["job"]
 	if !ok {

--- a/test/integration/prometheus/plugin/plugin.go
+++ b/test/integration/prometheus/plugin/plugin.go
@@ -21,7 +21,7 @@ sum(rate(integration_test{ {{.filter}}job="{{.job}}" }[{{"{{.window}}"}}]))`))
 
 var filterRegex = regexp.MustCompile(`([^=]+="[^=,"]+",)+`)
 
-func SLIPlugin(ctx context.Context, meta, labels, options map[string]string) (string, error) {
+func SLIPlugin(_ context.Context, _, labels, options map[string]string) (string, error) {
 	// Get job.
 	job, ok := options["job"]
 	if !ok {


### PR DESCRIPTION
Disable depguard as it's unconfigured and ignore the noop logger for unused parameters.